### PR TITLE
feat: 핸들 링크 solved.ac 전환 및 Camp Contest 탭 정리

### DIFF
--- a/apps/homepage/src/app/campcontest/[semester]/page.tsx
+++ b/apps/homepage/src/app/campcontest/[semester]/page.tsx
@@ -9,6 +9,7 @@ import type { Semester } from "src/types";
 import { formatLinkURL } from "src/utils/formatLinkURL";
 
 import { getAllSemesterRouters } from "src/utils/getAllSemesterRouters";
+import { hasCampContest } from "src/utils/hasCampContest";
 import { getSemesterFromString } from "src/utils/getSemesterFromString";
 import { makePageData } from "src/utils/makePageData";
 
@@ -40,7 +41,7 @@ function CampContestPage({
     allDataRouters,
     selectedTabIndex,
     renderedPageData: campContestData,
-  } = makePageData(currentPageSemester, "campContest");
+  } = makePageData(currentPageSemester, "campContest", hasCampContest);
 
   const currentSeason =
     currentPageSemester.season === "Winter" ? "겨울" : "여름";
@@ -126,7 +127,10 @@ function CampContestPage({
               columns={[
                 { key: "rank", header: "순위" },
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                {
+                  key: "bojHandle",
+                  header: "solved.ac 핸들",
+                },
                 { key: "school", header: "소속" },
               ]}
               fixedLayout
@@ -138,7 +142,10 @@ function CampContestPage({
                 data={contest.problemPicker}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ 핸들" },
+                  {
+                    key: "bojHandle",
+                    header: "solved.ac 핸들",
+                  },
                   { key: "school", header: "소속" },
                 ]}
                 fixedLayout
@@ -170,7 +177,7 @@ function CampContestPage({
 export default CampContestPage;
 
 export async function generateStaticParams() {
-  const allSemesters = getAllSemesterRouters();
+  const allSemesters = getAllSemesterRouters().filter(hasCampContest);
   return allSemesters.map((semester) => ({
     params: { semester: `${semester.year}-${semester.season}` },
   }));

--- a/apps/homepage/src/app/campcontest/page.tsx
+++ b/apps/homepage/src/app/campcontest/page.tsx
@@ -8,7 +8,8 @@ import React from "react";
 import type { Semester } from "src/types";
 import { formatLinkURL } from "src/utils/formatLinkURL";
 
-import { getCurrentSemester } from "src/utils/getCurrentSemester";
+import { getAllSemesterRouters } from "src/utils/getAllSemesterRouters";
+import { hasCampContest } from "src/utils/hasCampContest";
 import { makePageData } from "src/utils/makePageData";
 
 function CampContestIntro({ contestDateTime }: { contestDateTime: string }) {
@@ -29,20 +30,22 @@ function CampContestIntro({ contestDateTime }: { contestDateTime: string }) {
 
 // TODO: 2024 Summer 캠프 데이터 추가
 function CampContestPage() {
-  const currentSemester = getCurrentSemester();
+  // Camp Contest는 더 이상 열리지 않으므로, 현재 시즌 대신 마지막으로 열린 시즌을 보여준다.
+  // 학기 목록은 최신순이라 첫 번째 원소가 가장 최근에 열린 시즌이다.
+  const [latestSemester] = getAllSemesterRouters().filter(hasCampContest);
   const {
     allDataRouters,
     selectedTabIndex,
     renderedPageData: campContestData,
-  } = makePageData(currentSemester, "campContest");
+  } = makePageData(latestSemester, "campContest", hasCampContest);
 
   if (selectedTabIndex === -1) {
     notFound();
   }
 
-  const currentSeason = currentSemester.season === "Winter" ? "겨울" : "여름";
-  const pageTitle = `${currentSemester.year} ${currentSemester.season} Camp Contest`;
-  const pageSubTitle = `${currentSemester.year} ${currentSeason} 신촌지역 대학교 프로그래밍 동아리 연합 알고리즘 캠프 콘테스트`;
+  const currentSeason = latestSemester.season === "Winter" ? "겨울" : "여름";
+  const pageTitle = `${latestSemester.year} ${latestSemester.season} Camp Contest`;
+  const pageSubTitle = `${latestSemester.year} ${currentSeason} 신촌지역 대학교 프로그래밍 동아리 연합 알고리즘 캠프 콘테스트`;
 
   // TODO: note를 적당히 렌더링하기
   if (campContestData.contest.length === 0) {
@@ -71,28 +74,28 @@ function CampContestPage() {
           title: "문제(BOJ 링크)",
           href: formatLinkURL(
             campContestData.links.problemBojLink,
-            currentSemester,
+            latestSemester,
           ),
         },
         {
           title: "해설 PDF",
           href: formatLinkURL(
             campContestData.links.solutionPdf,
-            currentSemester,
+            latestSemester,
           ),
         },
         {
           title: "초급 스코어보드",
           href: formatLinkURL(
             campContestData.links.scoreboard?.[0],
-            currentSemester,
+            latestSemester,
           ),
         },
         {
           title: "중급 스코어보드",
           href: formatLinkURL(
             campContestData.links.scoreboard?.[1],
-            currentSemester,
+            latestSemester,
           ),
         },
       ].filter((link) => link.href) // 유효한 링크만 포함
@@ -123,7 +126,10 @@ function CampContestPage() {
               columns={[
                 { key: "rank", header: "순위" },
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                {
+                  key: "bojHandle",
+                  header: "solved.ac 핸들",
+                },
                 { key: "school", header: "소속" },
               ]}
               fixedLayout
@@ -135,7 +141,10 @@ function CampContestPage() {
                 data={contest.problemPicker}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ 핸들" },
+                  {
+                    key: "bojHandle",
+                    header: "solved.ac 핸들",
+                  },
                   { key: "school", header: "소속" },
                 ]}
                 fixedLayout

--- a/apps/homepage/src/app/camphistory/[semester]/page.tsx
+++ b/apps/homepage/src/app/camphistory/[semester]/page.tsx
@@ -62,7 +62,7 @@ function CampHistoryPage({
                 data={campStudy.lecturer}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout
@@ -76,7 +76,7 @@ function CampHistoryPage({
                 data={campStudy.mentor}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout

--- a/apps/homepage/src/app/camphistory/page.tsx
+++ b/apps/homepage/src/app/camphistory/page.tsx
@@ -56,7 +56,7 @@ function CampHistoryPage() {
                 data={campStudy.lecturer}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout
@@ -70,7 +70,7 @@ function CampHistoryPage() {
                 data={campStudy.mentor}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout

--- a/apps/homepage/src/app/halloffame/[semester]/page.tsx
+++ b/apps/homepage/src/app/halloffame/[semester]/page.tsx
@@ -93,7 +93,7 @@ function HallOfFamePage({
                 data={camp.lecturer}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout
@@ -106,7 +106,7 @@ function HallOfFamePage({
                 data={camp.mentor}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout

--- a/apps/homepage/src/app/halloffame/page.tsx
+++ b/apps/homepage/src/app/halloffame/page.tsx
@@ -83,7 +83,7 @@ function HallOfFamePage() {
                 data={camp.lecturer}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout
@@ -96,7 +96,7 @@ function HallOfFamePage() {
                 data={camp.mentor}
                 columns={[
                   { key: "name", header: "이름" },
-                  { key: "bojHandle", header: "BOJ" },
+                  { key: "bojHandle", header: "solved.ac" },
                   { key: "school", header: "학교" },
                 ]}
                 fixedLayout

--- a/apps/homepage/src/app/suapc/[semester]/page.tsx
+++ b/apps/homepage/src/app/suapc/[semester]/page.tsx
@@ -180,7 +180,7 @@ function SUAPCPage({
               data={suapcData.setter}
               columns={[
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                { key: "bojHandle", header: "solved.ac 핸들" },
                 { key: "school", header: "소속" },
               ]}
             />
@@ -189,7 +189,7 @@ function SUAPCPage({
               data={suapcData.reviewer}
               columns={[
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                { key: "bojHandle", header: "solved.ac 핸들" },
                 { key: "school", header: "소속" },
               ]}
             />

--- a/apps/homepage/src/app/suapc/page.tsx
+++ b/apps/homepage/src/app/suapc/page.tsx
@@ -173,7 +173,7 @@ function SUAPCPage() {
               data={suapcData.setter}
               columns={[
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                { key: "bojHandle", header: "solved.ac 핸들" },
                 { key: "school", header: "소속" },
               ]}
             />
@@ -182,7 +182,7 @@ function SUAPCPage() {
               data={suapcData.reviewer}
               columns={[
                 { key: "name", header: "이름" },
-                { key: "bojHandle", header: "BOJ 핸들" },
+                { key: "bojHandle", header: "solved.ac 핸들" },
                 { key: "school", header: "소속" },
               ]}
             />

--- a/apps/homepage/src/utils/compareSemester.ts
+++ b/apps/homepage/src/utils/compareSemester.ts
@@ -1,0 +1,15 @@
+import type { Semester } from "src/types";
+
+// 같은 해에서는 Winter(2월)가 Summer(8월)보다 앞선다
+const seasonOrder: Record<Semester["season"], number> = {
+  Winter: 0,
+  Summer: 1,
+};
+
+// a가 b보다 이르면 음수, 같으면 0, 늦으면 양수
+export function compareSemester(a: Semester, b: Semester) {
+  if (a.year !== b.year) {
+    return a.year - b.year;
+  }
+  return seasonOrder[a.season] - seasonOrder[b.season];
+}

--- a/apps/homepage/src/utils/hasCampContest.ts
+++ b/apps/homepage/src/utils/hasCampContest.ts
@@ -1,0 +1,10 @@
+import type { Semester } from "src/types";
+import { compareSemester } from "./compareSemester";
+
+// Camp Contest는 이 시즌을 마지막으로 더 이상 열리지 않는다.
+// 다시 열게 되면 이 값을 그 시즌으로 옮기고 데이터 파일을 추가한다.
+const lastCampContestSemester: Semester = { year: 2023, season: "Summer" };
+
+export function hasCampContest(semester: Semester) {
+  return compareSemester(semester, lastCampContestSemester) <= 0;
+}

--- a/apps/homepage/src/utils/makePageData.tsx
+++ b/apps/homepage/src/utils/makePageData.tsx
@@ -29,8 +29,13 @@ function checkDataFileExistence(
 export function makePageData<T extends DataType>(
   semester: Semester,
   dataType: T,
+  // 탭에 노출할 학기를 제한하고 싶을 때 넘긴다(예: Camp Contest는 열린 시즌까지만)
+  semesterFilter?: (semester: Semester) => boolean,
 ) {
-  const allDataRouters = getAllSemesterRouters();
+  const allSemesters = getAllSemesterRouters();
+  const allDataRouters = semesterFilter
+    ? allSemesters.filter(semesterFilter)
+    : allSemesters;
 
   // tab Nav에서 선택되어 있을 탭의 인덱스를 찾는다
   const selectedTabIndex = allDataRouters.findIndex(

--- a/apps/homepage/src/utils/renderHelpers.tsx
+++ b/apps/homepage/src/utils/renderHelpers.tsx
@@ -17,12 +17,17 @@ export function renderLink({
   );
 }
 
+// solved.ac는 BOJ 핸들을 그대로 쓰므로 모든 시즌에 동일하게 적용된다
+function makeHandleURL(handle: string) {
+  return `https://solved.ac/profile/${handle}`;
+}
+
 export function renderPerson<T extends { bojHandle: string }>(person: T) {
   return {
     ...person,
     bojHandle: renderLink({
       title: person.bojHandle,
-      url: `https://www.acmicpc.net/user/${person.bojHandle}`,
+      url: makeHandleURL(person.bojHandle),
     }),
   };
 }
@@ -49,7 +54,7 @@ export const renderProblem = (problem: Problem) => {
     }),
     setter: renderLink({
       title: problem.setter.name,
-      url: `https://www.acmicpc.net/user/${problem.setter.bojHandle}`,
+      url: makeHandleURL(problem.setter.bojHandle),
     }),
     setterSchool: problem.setter.school,
   };


### PR DESCRIPTION
# Feature Request

## 👉 PR 작업 내용

독립적인 두 가지 변경이라 커밋을 나눴습니다.

### 1. 핸들 링크와 표기를 solved.ac로 (`0dae011`)

- 강사·멘토·운영진·출제진·검수진·문제 출제자의 핸들 링크를 `acmicpc.net/user/{handle}` → `solved.ac/profile/{handle}`로 변경
- 핸들 열 머리말도 `BOJ` → `solved.ac`, `BOJ 핸들` → `solved.ac 핸들` (총 16곳)
- solved.ac가 BOJ 핸들을 그대로 쓰기 때문에 시즌 구분 없이 전 시즌에 동일하게 적용했습니다. 링크 생성이 `renderHelpers`의 `renderPerson`/`renderProblem` 한 곳에 모여 있어 변경 범위가 작습니다.

### 2. Camp Contest 탭을 마지막으로 열린 시즌까지만 (`e2496f8`)

Camp Contest는 **2023 Summer가 마지막**이고 이후로 열리지 않습니다. 그런데 탭 목록이 `semester.json`의 전체 학기를 따라가서, 시즌을 추가할 때마다 "아직 진행되지 않았습니다"만 뜨는 빈 탭이 계속 늘어나고 있었습니다.

- 탭을 2020 Summer ~ 2023 Summer 8개로 고정
- `/campcontest`는 현재 시즌 대신 마지막으로 열린 2023 Summer를 보여줍니다 (기존에는 현재 시즌을 보여줘서 빈 페이지가 떴습니다)
- 2024 이후 시즌 URL은 404
- 시즌 경계는 `hasCampContest`에, 학기 순서 비교는 `compareSemester`에 두었습니다. 다시 열게 되면 `hasCampContest.ts`의 시즌 값을 옮기고 데이터 파일을 추가하면 됩니다
- `makePageData`에 탭 학기를 제한하는 선택적 `semesterFilter` 인자를 추가했습니다

## 👉 요청 및 질문사항

- **`libs/data/campContest/`의 2024-Summer, 2024-Winter, 2025-Winter는 그대로 두었습니다.** "이번 시즌에는 Camp Contest가 진행되지 않았습니다" 안내만 담긴 빈 파일들인데, 이제 페이지가 404라 접근되지 않습니다. 지워도 되는지 판단이 필요해 손대지 않았습니다.
- 헤더 문구를 `solved.ac 핸들`로 했는데, 핸들 자체는 BOJ 핸들이라 표현이 어색하다면 `핸들`이나 다른 표기로 바꿀 수 있습니다.

## 📷 스크린샷

로컬 dev 서버 확인 결과:

- `/camphistory`(26S), `/camphistory/2026-Winter`, `/camphistory/2020-Winter` 모두 `solved.ac/profile/{handle}`로 연결되고 머리말이 `solved.ac`로 표시됩니다. `acmicpc.net/user` 링크는 코드베이스에 남아 있지 않습니다.
- `/suapc/2026-Winter`의 출제진·검수진·문제 출제자 링크 78개 모두 solved.ac로 전환됐습니다.
- `/campcontest` → `2023 Summer Camp Contest` 표시, 탭은 2020-Summer ~ 2023-Winter 8개만 노출됩니다.
- `/campcontest/2026-Summer` → 404, `/campcontest/2023-Summer` → 200
- `tsc --noEmit`과 `next build` 모두 통과했고, biome 경고는 main과 동일합니다(32개, 증감 없음).