### PR TITLE
fix: 시즌별 페이지가 500을 반환하던 문제 수정

### DIFF
--- a/apps/homepage/src/app/campcontest/[semester]/page.tsx
+++ b/apps/homepage/src/app/campcontest/[semester]/page.tsx
@@ -179,6 +179,6 @@ export default CampContestPage;
 export async function generateStaticParams() {
   const allSemesters = getAllSemesterRouters().filter(hasCampContest);
   return allSemesters.map((semester) => ({
-    params: { semester: `${semester.year}-${semester.season}` },
+    semester: `${semester.year}-${semester.season}`,
   }));
 }

--- a/apps/homepage/src/app/camphistory/[semester]/page.tsx
+++ b/apps/homepage/src/app/camphistory/[semester]/page.tsx
@@ -109,6 +109,6 @@ export default CampHistoryPage;
 export async function generateStaticParams() {
   const allSemesters = getAllSemesterRouters();
   return allSemesters.map((semester) => ({
-    params: { semester: `${semester.year}-${semester.season}` },
+    semester: `${semester.year}-${semester.season}`,
   }));
 }

--- a/apps/homepage/src/app/halloffame/[semester]/page.tsx
+++ b/apps/homepage/src/app/halloffame/[semester]/page.tsx
@@ -124,6 +124,6 @@ export default HallOfFamePage;
 export async function generateStaticParams() {
   const allSemesters = getAllSemesterRouters();
   return allSemesters.map((semester) => ({
-    params: { semester: `${semester.year}-${semester.season}` },
+    semester: `${semester.year}-${semester.season}`,
   }));
 }

--- a/apps/homepage/src/app/suapc/[semester]/page.tsx
+++ b/apps/homepage/src/app/suapc/[semester]/page.tsx
@@ -7,6 +7,7 @@ import TextSection from "@ui/TextSection";
 import React from "react";
 import type { Semester } from "src/types";
 import * as styles from "../styles.css";
+import { getAllSemesterRouters } from "src/utils/getAllSemesterRouters";
 import { getSemesterFromString } from "src/utils/getSemesterFromString";
 import { makePageData } from "src/utils/makePageData";
 import { formatLinkURL } from "src/utils/formatLinkURL";
@@ -201,3 +202,10 @@ function SUAPCPage({
 }
 
 export default SUAPCPage;
+
+export async function generateStaticParams() {
+  const allSemesters = getAllSemesterRouters();
+  return allSemesters.map((semester) => ({
+    semester: `${semester.year}-${semester.season}`,
+  }));
+}


### PR DESCRIPTION
# Feature Request

## 👉 PR 작업 내용

**현재 프로덕션에서 모든 시즌별 페이지가 500을 반환하고 있습니다.** 상단 탭으로 과거 시즌에 들어가면 에러가 납니다.

- https://icpc-sinchon.io/camphistory/2026-Winter → 500
- https://icpc-sinchon.io/halloffame/2025-Winter → 500
- https://icpc-sinchon.io/suapc/2026-Winter → 500
- https://icpc-sinchon.io/campcontest/2023-Summer → 500

(`/camphistory`, `/suapc` 같은 목록 페이지는 정상입니다)

### 원인

`generateStaticParams`가 `{ params: { semester } }`를 반환하고 있었습니다. App Router는 `{ semester }`를 기대하므로 **정적 경로가 하나도 생성되지 않았고**, 모든 요청이 런타임 서버 렌더링으로 넘어갔습니다.

그런데 `getDataFromFile`은 `process.cwd()/../../libs/data`를 `fs.readFileSync`로 읽습니다. 빌드 시점에는 레포 전체가 있으니 동작하지만, 서버리스 함수 번들에는 앱 바깥의 `libs/data`가 포함되지 않아 런타임에 파일을 찾지 못하고 500이 납니다.

`suapc/[semester]/notice`만 처음부터 올바른 형태여서 유일하게 정상 동작했고(`/suapc/2026-Winter/notice` → 200), 이게 원인 판별의 단서가 됐습니다.

`git log -S`로 확인한 결과 `7f562bb`(2024-11-07)부터 있던 문제입니다.

### 수정

- `camphistory`, `halloffame`, `campcontest`의 반환 형태를 `{ semester }`로 수정
- `generateStaticParams`가 아예 없어 항상 동적 렌더링(`ƒ`)되던 `suapc/[semester]`에 추가
- 정적 생성 페이지 **14개 → 64개**

## 👉 요청 및 질문사항

- **근본적으로는 앱 바깥 파일을 `fs`로 읽는 구조가 취약합니다.** 이번 수정은 모든 페이지를 빌드 타임에 프리렌더해서 런타임 `fs` 접근을 없애는 방식이라, 나중에 어떤 이유로든 동적 렌더링으로 넘어가면 같은 문제가 재발합니다. `libs/data`를 앱 안으로 옮기거나 import로 번들에 포함시키는 편이 안전해 보이는데, 별도 이슈로 다루면 좋겠습니다.
- 이 버그 때문에 그동안 시즌별 페이지 유입이 전부 에러를 봤을 텐데, 배포 후 확인이 필요합니다.

## 📷 스크린샷

빌드 출력 변화 (경로가 실제로 생성됨):

```
이전:
├ ● /camphistory/[semester]     170 B    (생성된 경로 없음)
├ ƒ /suapc/[semester]           181 B    (항상 동적 렌더링)
   Generating static pages (14/14)

이후:
├ ● /camphistory/[semester]     170 B
├   ├ /camphistory/2026-Summer
├   ├ /camphistory/2026-Winter
├   └ [+12 more paths]
├ ● /suapc/[semester]           181 B
├   ├ /suapc/2026-Summer
├   └ [+13 more paths]
 ✓ Generating static pages (64/64)
```

로컬 프로덕션 빌드(`next build && next start`) 확인 결과 전부 200입니다:

- `/camphistory/2026-Winter`, `/camphistory/2020-Winter`, `/halloffame/2025-Winter`, `/suapc/2026-Winter`, `/suapc/2026-Winter/notice`, `/campcontest/2023-Summer` → 200
- `/campcontest/2026-Summer`, `/campcontest/2024-Winter` → 404 (의도된 동작)
- solved.ac 링크도 그대로 유지됩니다

`tsc --noEmit` 통과, biome 경고는 main과 동일합니다(32개, 증감 없음).