### PR TITLE
feat: 26S 캠프 커리큘럼 추가

### DIFF
--- a/libs/data/campHistory/2026-Summer.json
+++ b/libs/data/campHistory/2026-Summer.json
@@ -11,6 +11,18 @@
           "school": "한양대학교",
           "bojHandle": "gubshig"
         }
+      ],
+      "curriculum": [
+        "PS란 무엇인가, 시간 복잡도, PS를 위한 C++",
+        "기초 정수론",
+        "수학적 귀납법, 재귀",
+        "브루트포스, 백트래킹",
+        "다양한 정렬 알고리즘, 우선순위 큐, STL 사용법",
+        "이분 탐색, 매개변수 탐색",
+        "다이나믹 프로그래밍",
+        "그리디 알고리즘",
+        "누적합, 투 포인터",
+        "문제 풀이 세션"
       ]
     },
     {
@@ -21,6 +33,18 @@
           "school": "부산대학교",
           "bojHandle": "qvixnh22"
         }
+      ],
+      "curriculum": [
+        "DP : Recursive formula / General DAG DP (implicit graph)",
+        "Queue / Stack / Heap / Deque / Tree set / Hash set",
+        "Graphs 1 : DFS / BFS / 0-1 BFS / Shortest path (Bellman-Ford, Floyd)",
+        "Graphs 2 : Digraph / Topological sort / Bipartite graph / Permutation cycle",
+        "Tree : DFS / BFS / Diameter / Euler tour",
+        "Binary search",
+        "Disjoint Union : Tree embedding / Path comprehension / Kruskal",
+        "Segment Tree : Recursive & Non-recursive / Segtree walk",
+        "Linear Algebra and Geometry : Vector expression / Graph expression (Path counting)",
+        "문제 풀이 세션"
       ]
     }
   ]


### PR DESCRIPTION
# Feature Request

## 👉 PR 작업 내용

시즌 오픈 당시 미확정이었던 26S 알고리즘 캠프 커리큘럼을 반영합니다.

- `campHistory/2026-Summer.json`의 초급/중급 study 항목에 `curriculum` 추가 (각 10회차)
- 초급: PS 입문·시간 복잡도부터 DP·그리디·투 포인터를 거쳐 문제 풀이 세션까지
- 중급: DP·자료구조·그래프·트리·세그먼트 트리 등을 거쳐 문제 풀이 세션까지

## 👉 요청 및 질문사항

- **회차별 날짜는 반영하지 않았습니다.** `campHistory` 스키마에 날짜 필드가 없고, 페이지도 `N회차 + 강의 주제`만 표시합니다. 기존 시즌 데이터도 날짜 없이 주제만 담고 있어 동일하게 맞췄습니다.
- **중급 "수강 권장 대상" 문구(기초 알고리즘까지 다룰 줄 아는 분 등)도 반영하지 않았습니다.** 이를 담을 필드가 스키마에 없습니다(`level`/`lecturer`/`mentor`/`curriculum`, `additionalProperties: false`). 사이트에 노출하려면 스키마와 렌더링 변경이 필요해 이번 PR 범위에서 제외했습니다. 필요하면 별도로 논의하면 좋겠습니다.

## 📷 스크린샷

로컬 확인 결과, `/camphistory`(현재 26S)에서 초급·중급 각각 "캠프 커리큘럼" 표가 1~10회차로 정상 렌더링됩니다. `tsc`/`next build` 통과, biome 통과입니다.