### PR TITLE
fix: 캠프 콘테스트 문제 목록 누락 및 후원 페이지 링크 오류 수정

### DIFF
--- a/apps/homepage/src/app/campcontest/[semester]/page.tsx
+++ b/apps/homepage/src/app/campcontest/[semester]/page.tsx
@@ -119,7 +119,7 @@ function CampContestPage({
         {campContestData.links && <ContestLinks links={contestLinks} />}
         <CampContestIntro contestDateTime={campContestData.dateTime} />
         {campContestData.contest.map((contest) => (
-          <React.Fragment key={contest.level}>
+          <React.Fragment key={`${contest.level}-${contest.contestName}`}>
             <TableSection
               title={`${contest.contestName} 수상자`}
               titleBadge={contest.level}

--- a/apps/homepage/src/app/campcontest/page.tsx
+++ b/apps/homepage/src/app/campcontest/page.tsx
@@ -118,7 +118,7 @@ function CampContestPage() {
         {campContestData.links && <ContestLinks links={contestLinks} />}
         <CampContestIntro contestDateTime={campContestData.dateTime} />
         {campContestData.contest.map((contest) => (
-          <React.Fragment key={contest.level}>
+          <React.Fragment key={`${contest.level}-${contest.contestName}`}>
             <TableSection
               title={`${contest.contestName} 수상자`}
               titleBadge={contest.level}

--- a/apps/homepage/src/app/sponsor/page.tsx
+++ b/apps/homepage/src/app/sponsor/page.tsx
@@ -137,7 +137,7 @@ function CorporateSponsorPage() {
                 <br />
                 {renderLink({
                   title: "20948번 Go와 함께하는 전화망 서비스",
-                  url: "https://www.acmicpc.net/problem/20943",
+                  url: "https://www.acmicpc.net/problem/20948",
                 })}
               </React.Fragment>,
             ]}

--- a/libs/data/campContest/2021-Summer.json
+++ b/libs/data/campContest/2021-Summer.json
@@ -124,7 +124,7 @@
           "bojHandle": "surface_03"
         }
       ],
-      "problem_list": [
+      "problemList": [
         {
           "problemTitle": "permutation making",
           "link": "https://www.acmicpc.net/problem/22952",


### PR DESCRIPTION
사이트 전체를 점검하다 발견한 버그를 수정합니다. 모두 오래 전부터 있던 문제입니다.

## 2021 Summer 캠프 콘테스트 중급 문제 목록 누락

데이터의 키가 `problemList`가 아니라 `problem_list`로 되어 있었습니다. 렌더링 코드는 `contest.problemList`의 존재만 확인하기 때문에 조용히 건너뛰었고, 중급 문제 7개가 화면에 나오지 않았습니다.

누락되던 문제: permutation making, 짝수싫어수, 안산 탐지기, 신촌의 수열과 쿼리, 미팅, 여행사 운영하기, 신촌방위본부

## 캠프 콘테스트 React key 중복

2020 Summer와 2020 Winter는 중간고사와 기말고사가 각각 초급, 중급으로 들어 있어 `level`이 `[초급, 초급, 중급, 중급]`입니다. 여기에 `key={contest.level}`을 쓰고 있어 key가 중복됐습니다.

현재 화면 출력 자체는 정상이지만 React 경고가 발생하고, 목록이 갱신될 때 상태가 어긋날 수 있습니다. `level`과 `contestName`을 조합한 key로 변경했습니다. 두 값의 조합은 전체 데이터 파일에서 고유한 것을 확인했습니다.

## 후원 페이지 문제 링크 오류

`후원 및 협업` 페이지 NAVER D2 항목의 "20948번 Go와 함께하는 전화망 서비스" 링크가 20943번(카카오톡)을 가리키고 있었습니다. 바로 위 카카오 항목에서 복사하며 URL을 수정하지 않은 것으로 보입니다. `libs/data/suapc/2021-Winter.json`에는 20948번으로 올바르게 기록되어 있습니다.

## 확인

- `next build` 통과, 정적 페이지 64개 생성(기존과 동일)
- `tsc --noEmit` 통과
- 2021 Summer 페이지에서 중급 문제 목록 7개 노출 확인
- 2020 Summer, 2020 Winter 페이지 섹션 수 변화 없음
