### PR TITLE
feat: 기업 후원 페이지에 Dify 추가

### DIFF
--- a/apps/homepage/src/app/sponsor/page.tsx
+++ b/apps/homepage/src/app/sponsor/page.tsx
@@ -182,6 +182,13 @@ function CorporateSponsorPage() {
             }}
             items={["Dify 해커톤 진행"]}
           />
+          <ListSection
+            logoSource={{
+              name: "Dify 로고",
+              src: "/res/sponsor-ci/dify.png",
+            }}
+            items={["Dify 해커톤 진행"]}
+          />
         </div>
         <section className={styles.container}>
           <Title>


### PR DESCRIPTION
미소정보기술 옆에 Dify 로고와 "Dify 해커톤 진행" 항목을 추가했습니다.

로고 이미지(`public/res/sponsor-ci/dify.png`)는 #31에서 이미 추가되어 있어 이번 변경은 `sponsor/page.tsx` 한 곳입니다.