### PR TITLE
feat: 메인 페이지 대회 홍보 영역과 홍보 팝업 추가

### DIFF
--- a/apps/homepage/src/app/layout.tsx
+++ b/apps/homepage/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import Header from "@ui/Header";
 import Footer from "@ui/Footer";
 import PageLayout from "@ui/PageLayout";
+import PromotionPopup from "@ui/PromotionPopup";
 
 import "@styles/reset.css";
 import "@styles/theme.css";
@@ -19,6 +20,7 @@ export default function RootLayout({
         <Header />
         <PageLayout>{children}</PageLayout>
         <Footer />
+        <PromotionPopup />
       </body>
     </html>
   );

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -1,12 +1,17 @@
 import MainContainer from "@components/MainContainer";
 import IntroCard from "@ui/IntroCard";
 import MainBanner from "@ui/MainBanner";
+import PromotionSection from "@ui/PromotionSection";
+import { getPromotionData } from "src/utils/getPromotionData";
 
 // TODO: 메타데이터 추가
 function HomePage() {
+  const promotionData = getPromotionData();
+
   return (
     <>
       <MainBanner />
+      {promotionData && <PromotionSection {...promotionData} />}
       <MainContainer title="캠프 소개">
         <IntroCard
           imageSrc="/res/ferris-wheel.gif"

--- a/apps/homepage/src/components/PosterFrame/index.tsx
+++ b/apps/homepage/src/components/PosterFrame/index.tsx
@@ -1,0 +1,22 @@
+import * as styles from "./styles.css";
+
+type Props = {
+  imageURL: string;
+  alt: string;
+};
+
+// 포스터는 4:5 비율로 제작되므로, 포스터가 아직 없어도 같은 비율의 자리를 잡아둔다.
+// 너비는 이 컴포넌트를 쓰는 쪽에서 정한다.
+function PosterFrame({ imageURL, alt }: Props) {
+  return (
+    <div className={styles.frame}>
+      {imageURL ? (
+        <img src={imageURL} alt={alt} className={styles.poster} />
+      ) : (
+        <p className={styles.placeholder}>포스터 준비 중입니다</p>
+      )}
+    </div>
+  );
+}
+
+export default PosterFrame;

--- a/apps/homepage/src/components/PosterFrame/styles.css.ts
+++ b/apps/homepage/src/components/PosterFrame/styles.css.ts
@@ -1,0 +1,29 @@
+import { vars } from "@styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const frame = style({
+  width: "100%",
+  aspectRatio: "4 / 5",
+
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  overflow: "hidden",
+
+  border: `1px solid ${vars.colors.primaryBorder}`,
+  backgroundColor: vars.colors.primaryBackground,
+});
+
+// 포스터 비율이 4:5와 조금 달라도 잘리지 않도록 contain으로 맞춘다
+export const poster = style({
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+});
+
+export const placeholder = style({
+  padding: "1rem",
+  fontSize: "0.9rem",
+  color: vars.colors.primaryText,
+  textAlign: "center",
+});

--- a/apps/homepage/src/types/suapc.ts
+++ b/apps/homepage/src/types/suapc.ts
@@ -25,6 +25,10 @@ export interface SUAPCData {
    */
   titleSuffix?: string;
   /**
+   * 대회 홍보 정보. 홍보 기간에만 사용하고, 대회가 끝나면 지운다
+   */
+  promotion?: Promotion;
+  /**
    * 연합 대회 관련 링크
    */
   links: {
@@ -69,6 +73,24 @@ export interface SUAPCData {
    * SUAPC의 개인 후원자
    */
   personalSponsor?: Sponsor[];
+}
+export interface Promotion {
+  /**
+   * 4:5 비율의 홍보 포스터 이미지. http로 시작하지 않으면 시즌별 폴더(/res/2026s 등)에서 찾는다
+   */
+  posterImage?: string;
+  /**
+   * 참가 신청 폼(구글 폼) 링크
+   */
+  applyLink?: string;
+  /**
+   * 참가 신청 기간 안내 문구
+   */
+  applyPeriod?: string;
+  /**
+   * 홈페이지 접속 시 홍보 팝업을 띄울지 여부
+   */
+  showPopup?: boolean;
 }
 export interface Contest {
   /**

--- a/apps/homepage/src/ui/PromotionPopup/PromotionPopupClient.tsx
+++ b/apps/homepage/src/ui/PromotionPopup/PromotionPopupClient.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import PosterFrame from "@components/PosterFrame";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import type { PromotionData } from "src/utils/getPromotionData";
+import * as styles from "./styles.css";
+
+const STORAGE_KEY_PREFIX = "icpc-sinchon-promotion-popup";
+
+// 브라우저가 스토리지 사용을 막아둔 경우에도 팝업 자체는 동작해야 한다
+function readStorageItem(storage: Storage, key: string) {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorageItem(storage: Storage, key: string, value: string) {
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // 저장에 실패하면 다음 방문에 팝업이 다시 보이는 것 외에 문제는 없다
+  }
+}
+
+function getTodayKey() {
+  const today = new Date();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const date = String(today.getDate()).padStart(2, "0");
+
+  return `${today.getFullYear()}-${month}-${date}`;
+}
+
+function PromotionPopupClient({
+  promotionId,
+  contestTitle,
+  contestPageURL,
+  dateTime,
+  posterURL,
+  applyLink,
+  applyPeriod,
+}: PromotionData) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const [hideToday, setHideToday] = useState(false);
+
+  const hiddenDateKey = `${STORAGE_KEY_PREFIX}-${promotionId}-hidden-date`;
+  const closedInSessionKey = `${STORAGE_KEY_PREFIX}-${promotionId}-closed`;
+  const applyPeriodText = applyPeriod ? `참가 신청 기간 ${applyPeriod}` : "";
+
+  // 방문자가 팝업을 닫았는지는 브라우저에만 기록되므로, 팝업은 마운트 이후에 띄운다
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || dialog.open) {
+      return;
+    }
+
+    const hiddenDate = readStorageItem(window.localStorage, hiddenDateKey);
+    const closedInSession = readStorageItem(
+      window.sessionStorage,
+      closedInSessionKey,
+    );
+
+    if (hiddenDate === getTodayKey() || closedInSession === "true") {
+      return;
+    }
+
+    dialog.showModal();
+    document.body.style.overflow = "hidden";
+  }, [hiddenDateKey, closedInSessionKey]);
+
+  const closePopup = () => {
+    dialogRef.current?.close();
+  };
+
+  // 클릭 지점이 dialog 자신이면 내용 밖(배경)을 클릭한 것이다
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current) {
+      closePopup();
+    }
+  };
+
+  // 닫기 버튼, 배경 클릭, ESC 모두 close 이벤트로 모인다
+  const handleClose = () => {
+    if (hideToday) {
+      writeStorageItem(window.localStorage, hiddenDateKey, getTodayKey());
+    }
+
+    writeStorageItem(window.sessionStorage, closedInSessionKey, "true");
+    document.body.style.overflow = "";
+  };
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: 키보드에서는 dialog가 기본 지원하는 ESC로 닫는다
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      onClose={handleClose}
+      onClick={handleBackdropClick}
+      aria-labelledby="promotion-popup-title"
+    >
+      <div className={styles.content}>
+        <p className={styles.label}>참가자 모집</p>
+        <h2 id="promotion-popup-title" className={styles.title}>
+          {contestTitle}
+        </h2>
+        {posterURL && (
+          <PosterFrame imageURL={posterURL} alt={`${contestTitle} 포스터`} />
+        )}
+        <p className={styles.description}>{dateTime}</p>
+        {applyPeriodText && (
+          <p className={styles.description}>{applyPeriodText}</p>
+        )}
+        <div className={styles.buttonContainer}>
+          {applyLink && (
+            <a
+              href={applyLink}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.applyButton}
+            >
+              참가 신청하기
+            </a>
+          )}
+          <Link
+            href={contestPageURL}
+            className={styles.detailLink}
+            onClick={closePopup}
+          >
+            대회 안내 보기
+          </Link>
+        </div>
+      </div>
+      <div className={styles.footer}>
+        <label className={styles.hideTodayLabel}>
+          <input
+            type="checkbox"
+            checked={hideToday}
+            onChange={(event) => setHideToday(event.target.checked)}
+          />
+          오늘 하루 보지 않기
+        </label>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={closePopup}
+        >
+          닫기
+        </button>
+      </div>
+    </dialog>
+  );
+}
+
+export default PromotionPopupClient;

--- a/apps/homepage/src/ui/PromotionPopup/index.tsx
+++ b/apps/homepage/src/ui/PromotionPopup/index.tsx
@@ -1,0 +1,19 @@
+import { getPromotionData } from "src/utils/getPromotionData";
+import PromotionPopupClient from "./PromotionPopupClient";
+
+// 홍보 팝업은 현재 시즌 데이터에서 showPopup을 켜고, 보여줄 내용이 있을 때만 띄운다
+function PromotionPopup() {
+  const promotionData = getPromotionData();
+
+  if (!promotionData?.showPopup) {
+    return null;
+  }
+
+  if (!promotionData.posterURL && !promotionData.applyLink) {
+    return null;
+  }
+
+  return <PromotionPopupClient {...promotionData} />;
+}
+
+export default PromotionPopup;

--- a/apps/homepage/src/ui/PromotionPopup/styles.css.ts
+++ b/apps/homepage/src/ui/PromotionPopup/styles.css.ts
@@ -1,0 +1,117 @@
+import { vars } from "@styles/theme.css";
+import { globalStyle, style } from "@vanilla-extract/css";
+
+// 전역 리셋이 margin을 0으로 만들기 때문에, 가운데 정렬을 위해 margin을 다시 지정한다
+export const dialog = style({
+  width: "min(24rem, 90vw)",
+  maxHeight: "90vh",
+  overflowY: "auto",
+
+  margin: "auto",
+  padding: 0,
+  border: "none",
+
+  backgroundColor: vars.colors.white,
+  boxShadow: "0 4px 16px rgba(0, 0, 0, 0.2)",
+});
+
+globalStyle(`${dialog}::backdrop`, {
+  backgroundColor: "rgba(0, 0, 0, 0.5)",
+});
+
+export const content = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+
+  padding: "1.5rem 1.5rem 1rem",
+});
+
+export const label = style({
+  fontSize: "0.9rem",
+  fontWeight: 700,
+  color: vars.colors.primarySurface,
+});
+
+export const title = style({
+  fontWeight: 700,
+  fontSize: "1.3rem",
+  letterSpacing: "-0.04em",
+  lineHeight: 1.2,
+
+  marginBottom: "0.5rem",
+});
+
+export const description = style({
+  fontSize: "0.9rem",
+  lineHeight: 1.6,
+  color: vars.colors.primaryText,
+});
+
+export const buttonContainer = style({
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  gap: "0.75rem",
+
+  marginTop: "0.5rem",
+});
+
+// PromotionSection의 버튼들과 같은 크기를 유지한다
+const buttonBase = style({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: `2px solid ${vars.colors.primarySurface}`,
+  padding: "0.4rem 1.2rem",
+  fontSize: "0.8rem",
+  fontWeight: 700,
+  textDecoration: "none",
+});
+
+export const applyButton = style([
+  buttonBase,
+  {
+    color: vars.colors.white,
+    backgroundColor: vars.colors.primarySurface,
+  },
+]);
+
+export const detailLink = style([
+  buttonBase,
+  {
+    color: vars.colors.primarySurface,
+  },
+]);
+
+export const footer = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "0.5rem",
+
+  padding: "0.75rem 1.5rem",
+
+  borderTop: `1px solid ${vars.colors.primaryAccentBackground}`,
+  backgroundColor: vars.colors.primaryBackground,
+});
+
+export const hideTodayLabel = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.4rem",
+
+  fontSize: "0.85rem",
+  color: vars.colors.primaryText,
+  cursor: "pointer",
+});
+
+export const closeButton = style({
+  padding: "0.3rem 0.9rem",
+  border: `1px solid ${vars.colors.primaryBorder}`,
+  fontSize: "0.85rem",
+  fontWeight: 700,
+  color: vars.colors.primaryText,
+  backgroundColor: vars.colors.white,
+  cursor: "pointer",
+});

--- a/apps/homepage/src/ui/PromotionSection/index.tsx
+++ b/apps/homepage/src/ui/PromotionSection/index.tsx
@@ -1,0 +1,45 @@
+import LinkButton from "@components/LinkButton";
+import PosterFrame from "@components/PosterFrame";
+import Text from "@components/Text";
+import type { PromotionData } from "src/utils/getPromotionData";
+import * as styles from "./styles.css";
+
+function PromotionSection({
+  contestTitle,
+  contestPageURL,
+  dateTime,
+  posterURL,
+  applyLink,
+  applyPeriod,
+}: PromotionData) {
+  return (
+    <section className={styles.container}>
+      <div className={styles.posterContainer}>
+        <PosterFrame imageURL={posterURL} alt={`${contestTitle} 포스터`} />
+      </div>
+      <div className={styles.infoContainer}>
+        <p className={styles.label}>참가자 모집</p>
+        <h2 className={styles.title}>{contestTitle}</h2>
+        <Text>{dateTime}</Text>
+        {applyPeriod && <Text>{`참가 신청 기간 ${applyPeriod}`}</Text>}
+        <div className={styles.buttonContainer}>
+          {applyLink && (
+            <a
+              href={applyLink}
+              target="_blank"
+              rel="noreferrer"
+              className={styles.applyButton}
+            >
+              참가 신청하기
+            </a>
+          )}
+          <LinkButton href={contestPageURL} disabled={false}>
+            대회 안내 보기
+          </LinkButton>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default PromotionSection;

--- a/apps/homepage/src/ui/PromotionSection/styles.css.ts
+++ b/apps/homepage/src/ui/PromotionSection/styles.css.ts
@@ -1,0 +1,69 @@
+import { vars } from "@styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "90%",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "1.5rem",
+
+  padding: "2rem 0",
+  margin: "0 auto",
+
+  "@media": {
+    "screen and (min-width: 768px)": {
+      flexDirection: "row",
+      justifyContent: "center",
+      gap: "2.5rem",
+    },
+  },
+});
+
+export const posterContainer = style({
+  width: "100%",
+  maxWidth: "20rem",
+  flexShrink: 0,
+});
+
+export const infoContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+});
+
+export const label = style({
+  fontSize: "0.9rem",
+  fontWeight: 700,
+  color: vars.colors.primarySurface,
+});
+
+export const title = style({
+  fontWeight: 700,
+  fontSize: "1.8rem",
+  letterSpacing: "-0.04em",
+  lineHeight: 1.2,
+});
+
+export const buttonContainer = style({
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  gap: "0.75rem",
+
+  marginTop: "0.5rem",
+});
+
+// LinkButton과 크기를 맞추고, 배경을 채워 주된 행동임을 드러낸다
+export const applyButton = style({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: `2px solid ${vars.colors.primarySurface}`,
+  padding: "0.4rem 1.2rem",
+  fontSize: "0.8rem",
+  fontWeight: 700,
+  color: vars.colors.white,
+  backgroundColor: vars.colors.primarySurface,
+  textDecoration: "none",
+});

--- a/apps/homepage/src/utils/getPromotionData.ts
+++ b/apps/homepage/src/utils/getPromotionData.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { SUAPCData } from "src/types/suapc";
+import { formatLinkURL } from "./formatLinkURL";
+import { getCurrentSemester } from "./getCurrentSemester";
+import { getDataFromFile } from "./getDataFromFile";
+
+export type PromotionData = {
+  // 팝업을 다시 보지 않기로 한 기록을 시즌별로 남기기 위한 식별자
+  promotionId: string;
+  contestTitle: string;
+  contestPageURL: string;
+  dateTime: string;
+  // 아직 준비되지 않은 값은 빈 문자열이다
+  posterURL: string;
+  applyLink: string;
+  applyPeriod: string;
+  showPopup: boolean;
+};
+
+// 현재 시즌 데이터에 promotion이 있을 때만 홍보 영역과 팝업을 노출한다.
+// 홍보가 끝나면 데이터 파일에서 promotion을 지운다.
+export function getPromotionData(): PromotionData | null {
+  const semester = getCurrentSemester();
+  const dataFilePath = path.join(
+    process.cwd(),
+    "..",
+    "..",
+    "libs",
+    "data",
+    "suapc",
+    `${semester.year}-${semester.season}.json`,
+  );
+
+  if (!fs.existsSync(dataFilePath)) {
+    return null;
+  }
+
+  const suapcData: SUAPCData = getDataFromFile(
+    "suapc",
+    semester.year,
+    semester.season,
+  );
+  const promotion = suapcData.promotion;
+
+  if (!promotion) {
+    return null;
+  }
+
+  return {
+    promotionId: `${semester.year}-${semester.season}`,
+    contestTitle: `SUAPC ${semester.year} ${semester.season}${suapcData.titleSuffix ? ` ${suapcData.titleSuffix}` : ""}`,
+    contestPageURL: `/suapc/${semester.year}-${semester.season}`,
+    dateTime: suapcData.dateTime,
+    posterURL: formatLinkURL(promotion.posterImage, semester),
+    applyLink: promotion.applyLink ?? "",
+    applyPeriod: promotion.applyPeriod ?? "",
+    showPopup: promotion.showPopup ?? false,
+  };
+}

--- a/libs/data/suapc/2026-Summer.json
+++ b/libs/data/suapc/2026-Summer.json
@@ -5,6 +5,9 @@
   "dateTime": "2026년 8월 25일(화) 오전 11시 ~ 오후 4시",
   "note": "대회 기본 정보만 반영했습니다. Dify 해커톤 세션을 포함하여 진행됩니다. 후원사, 개인 후원자, 링크, 대회 결과는 추후 추가 예정입니다.",
   "titleSuffix": "× Dify Hackathon",
+  "promotion": {
+    "showPopup": true
+  },
   "links": {},
   "contest": [],
   "setter": [],

--- a/libs/data/suapc/schema.json
+++ b/libs/data/suapc/schema.json
@@ -67,6 +67,28 @@
       "type": "string",
       "description": "대회 타이틀 뒤에 덧붙일 문구(예: \"× Dify Hackathon\")"
     },
+    "promotion": {
+      "type": "object",
+      "description": "대회 홍보 정보. 홍보 기간에만 사용하고, 대회가 끝나면 지운다",
+      "properties": {
+        "posterImage": {
+          "type": "string",
+          "description": "4:5 비율의 홍보 포스터 이미지. http로 시작하지 않으면 시즌별 폴더(/res/2026s 등)에서 찾는다"
+        },
+        "applyLink": {
+          "type": "string",
+          "description": "참가 신청 폼(구글 폼) 링크"
+        },
+        "applyPeriod": {
+          "type": "string",
+          "description": "참가 신청 기간 안내 문구"
+        },
+        "showPopup": {
+          "type": "boolean",
+          "description": "홈페이지 접속 시 홍보 팝업을 띄울지 여부"
+        }
+      }
+    },
     "links": {
       "type": "object",
       "description": "연합 대회 관련 링크",


### PR DESCRIPTION
홈페이지를 대회 홍보에 쓸 수 있도록 4:5 포스터 영역과 홍보 팝업을 추가했습니다.

## 데이터
포스터와 신청 링크는 시즌 데이터에서 읽습니다. `libs/data/suapc/{시즌}.json`에 `promotion`을 추가했고, `schema.json`과 `types/suapc.ts`도 함께 맞췄습니다.

```json
"promotion": {
  "posterImage": "SUAPC_2026s_Poster.png",
  "applyLink": "https://forms.gle/...",
  "applyPeriod": "...",
  "showPopup": true
}
```

`posterImage`는 `http`로 시작하지 않으면 `/res/{연도}{계절}` 아래에서 찾습니다. 홍보가 끝나면 `promotion`을 지우면 홍보 영역과 팝업이 함께 사라집니다.

## 포스터 영역
- `components/PosterFrame`: 4:5 비율 프레임. 포스터가 없으면 같은 비율의 자리만 잡아둡니다.
- `ui/PromotionSection`: 메인 배너 아래에 포스터, 대회명, 일자, 신청 기간, 참가 신청 버튼을 배치합니다.

## 홍보 팝업
- `ui/PromotionPopup`: 루트 레이아웃에서 렌더링하며, 네이티브 `dialog`의 `showModal`을 사용해 ESC와 포커스 처리를 브라우저에 맡깁니다.
- `오늘 하루 보지 않기`를 체크하고 닫으면 localStorage에 그날 날짜를 저장해 자정까지 띄우지 않습니다. 체크 없이 닫으면 sessionStorage에만 기록해 해당 세션에서만 띄우지 않습니다.
- 저장 키에 시즌이 들어가서 다음 시즌 팝업이 이전 기록에 막히지 않습니다.
- `showPopup`이 켜져 있고 포스터나 신청 링크가 하나라도 있을 때만 뜹니다. 지금은 둘 다 비어 있어 팝업은 노출되지 않습니다.

## 확인
- 임시 데이터로 dev 서버에서 홍보 영역과 팝업 렌더링, 포스터 경로, 팝업 재노출 조건 확인 후 되돌렸습니다.
- `tsc --noEmit` 통과, 프로덕션 빌드 64페이지 정상, Biome 신규 지적 없음.