### PR TITLE
fix: 포스터와 신청 링크가 없어도 홍보 팝업 노출

### DIFF
--- a/apps/homepage/src/ui/PromotionPopup/PromotionPopupClient.tsx
+++ b/apps/homepage/src/ui/PromotionPopup/PromotionPopupClient.tsx
@@ -105,9 +105,7 @@ function PromotionPopupClient({
         <h2 id="promotion-popup-title" className={styles.title}>
           {contestTitle}
         </h2>
-        {posterURL && (
-          <PosterFrame imageURL={posterURL} alt={`${contestTitle} 포스터`} />
-        )}
+        <PosterFrame imageURL={posterURL} alt={`${contestTitle} 포스터`} />
         <p className={styles.description}>{dateTime}</p>
         {applyPeriodText && (
           <p className={styles.description}>{applyPeriodText}</p>

--- a/apps/homepage/src/ui/PromotionPopup/index.tsx
+++ b/apps/homepage/src/ui/PromotionPopup/index.tsx
@@ -1,15 +1,11 @@
 import { getPromotionData } from "src/utils/getPromotionData";
 import PromotionPopupClient from "./PromotionPopupClient";
 
-// 홍보 팝업은 현재 시즌 데이터에서 showPopup을 켜고, 보여줄 내용이 있을 때만 띄운다
+// 홍보 팝업은 현재 시즌 데이터에서 showPopup을 켰을 때만 띄운다
 function PromotionPopup() {
   const promotionData = getPromotionData();
 
   if (!promotionData?.showPopup) {
-    return null;
-  }
-
-  if (!promotionData.posterURL && !promotionData.applyLink) {
     return null;
   }
 


### PR DESCRIPTION
홍보 팝업을 `showPopup`만으로 켜지도록 바꿨습니다.

기존에는 포스터나 신청 링크가 하나라도 있어야 팝업을 띄웠는데, 두 자료가 준비되기 전에도 대회를 알릴 수 있도록 조건을 없앴습니다. 포스터가 없는 동안에는 팝업 안에서도 4:5 자리만 표시합니다.

포스터와 구글 폼이 준비되면 `libs/data/suapc/2026-Summer.json`의 `promotion`에 `posterImage`, `applyLink`를 채우면 그대로 반영됩니다.