### PR TITLE
feat: SUAPC 2026 Summer 참가 신청 폼 링크 추가

### DIFF
--- a/libs/data/suapc/2026-Summer.json
+++ b/libs/data/suapc/2026-Summer.json
@@ -6,6 +6,7 @@
   "note": "대회 기본 정보만 반영했습니다. Dify 해커톤 세션을 포함하여 진행됩니다. 후원사, 개인 후원자, 링크, 대회 결과는 추후 추가 예정입니다.",
   "titleSuffix": "× Dify Hackathon",
   "promotion": {
+    "applyLink": "https://forms.gle/jNPguE13zVRdejSa7",
     "showPopup": true
   },
   "links": {},


### PR DESCRIPTION
홍보 섹션과 팝업의 `참가 신청하기` 버튼이 가리킬 구글 폼 링크를 `promotion.applyLink`에 넣었습니다.