### PR TITLE
fix: SUAPC 2026 Summer 대회 일자를 신청서 일정과 통일

### DIFF
--- a/libs/data/suapc/2026-Summer.json
+++ b/libs/data/suapc/2026-Summer.json
@@ -2,7 +2,7 @@
   "$schema": "./schema.json",
   "year": 2026,
   "season": "Summer",
-  "dateTime": "2026년 8월 25일(화) 오전 11시 ~ 오후 4시",
+  "dateTime": "2026년 8월 25일(화) 오전 11시 30분 ~ 오후 7시 (본 대회 오전 11시 30분 ~ 오후 4시 30분, Dify 해커톤 오후 4시 50분 ~ 오후 5시 40분)",
   "note": "대회 기본 정보만 반영했습니다. Dify 해커톤 세션을 포함하여 진행됩니다. 후원사, 개인 후원자, 링크, 대회 결과는 추후 추가 예정입니다.",
   "titleSuffix": "× Dify Hackathon",
   "promotion": {


### PR DESCRIPTION
홈페이지의 대회 일자가 참가 신청서 일정과 달라서 맞췄습니다. 본 대회와 Dify 해커톤 시간도 함께 적었습니다.