### PR TITLE
chore: 참가 신청 마감에 따른 홍보 팝업 해제 및 대회 링크 정리

### DIFF
--- a/apps/homepage/src/app/campcontest/[semester]/page.tsx
+++ b/apps/homepage/src/app/campcontest/[semester]/page.tsx
@@ -72,7 +72,7 @@ function CampContestPage({
   const contestLinks = campContestData.links
     ? [
         {
-          title: "문제(BOJ 링크)",
+          title: "문제",
           href: formatLinkURL(
             campContestData.links.problemBojLink,
             currentPageSemester,

--- a/apps/homepage/src/app/campcontest/page.tsx
+++ b/apps/homepage/src/app/campcontest/page.tsx
@@ -71,7 +71,7 @@ function CampContestPage() {
   const contestLinks = campContestData.links
     ? [
         {
-          title: "문제(BOJ 링크)",
+          title: "문제",
           href: formatLinkURL(
             campContestData.links.problemBojLink,
             latestSemester,

--- a/apps/homepage/src/app/suapc/[semester]/notice/page.tsx
+++ b/apps/homepage/src/app/suapc/[semester]/notice/page.tsx
@@ -216,7 +216,7 @@ function SUAPCNoticePage({
   const links = suapcData.links ?? {};
   const contestLinks = [
     {
-      title: "문제(BOJ 링크)",
+      title: "문제",
       href: formatLinkURL(links.problemBojLink, currentPageSemester),
     },
     {

--- a/apps/homepage/src/app/suapc/[semester]/page.tsx
+++ b/apps/homepage/src/app/suapc/[semester]/page.tsx
@@ -70,7 +70,7 @@ function SUAPCPage({
   const links = suapcData.links ?? {};
   const contestLinks = [
     {
-      title: "문제(BOJ 링크)",
+      title: "문제",
       href: formatLinkURL(links.problemBojLink, currentPageSemester),
     },
     {
@@ -118,9 +118,7 @@ function SUAPCPage({
         }
       />
       <HistoryLayout title={pageTitle} subTitle={pageSubTitle}>
-        {hasAnyLinkButton && (
-          <ContestLinks links={contestLinks} />
-        )}
+        {hasAnyLinkButton && <ContestLinks links={contestLinks} />}
         <TextSection title="대회 일자" text={suapcData.dateTime} />
         <TextSection title="대회 소개" text={suapcDescription} />
         <TextSection title="참가 대상" text={participantDescription} />

--- a/apps/homepage/src/app/suapc/page.tsx
+++ b/apps/homepage/src/app/suapc/page.tsx
@@ -63,7 +63,7 @@ function SUAPCPage() {
   const links = suapcData.links ?? {};
   const contestLinks = [
     {
-      title: "문제(BOJ 링크)",
+      title: "문제",
       href: formatLinkURL(links.problemBojLink, currentSemester),
     },
     {
@@ -111,9 +111,7 @@ function SUAPCPage() {
         }
       />
       <HistoryLayout title={pageTitle} subTitle={pageSubTitle}>
-        {hasAnyLinkButton && (
-          <ContestLinks links={contestLinks} />
-        )}
+        {hasAnyLinkButton && <ContestLinks links={contestLinks} />}
         <TextSection title="대회 일자" text={suapcData.dateTime} />
         <TextSection title="대회 소개" text={suapcDescription} />
         <TextSection title="참가 대상" text={participantDescription} />

--- a/libs/data/suapc/2026-Summer.json
+++ b/libs/data/suapc/2026-Summer.json
@@ -8,9 +8,11 @@
   "promotion": {
     "posterImage": "SUAPC_2026s_Poster.png",
     "applyLink": "https://forms.gle/jNPguE13zVRdejSa7",
-    "showPopup": true
+    "showPopup": false
   },
-  "links": {},
+  "links": {
+    "posterImage": "https://drive.google.com/file/d/17yExzOOqt9YiRDO37jT_HFihbZM0jM1g/view?usp=sharing"
+  },
   "contest": [],
   "setter": [],
   "reviewer": [],


### PR DESCRIPTION
- 참가 신청이 마감되어 홍보 팝업을 껐습니다(`promotion.showPopup: false`).
- 26S 공식 포스터 링크를 `links.posterImage`에 넣어 대회 페이지 버튼을 살렸습니다.
- 상단 링크 버튼의 `문제(BOJ 링크)` 표기를 `문제`로 줄였습니다. SUAPC와 캠프 콘테스트 페이지 모두 적용했습니다.